### PR TITLE
use the recommended Quarkus approach of access modifiers

### DIFF
--- a/app/src/main/java/io/graphqlcrud/app/GraphQLResource.java
+++ b/app/src/main/java/io/graphqlcrud/app/GraphQLResource.java
@@ -48,16 +48,18 @@ import io.graphqlcrud.model.Schema;
 public class GraphQLResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphQLResource.class);
 
-    @Inject
     private AgroalDataSource datasource;
-
     private GraphQLSchema schema;
-
-    @ConfigProperty(name = "graphqlcrud.datasource.schema")
     private String dbSchemaName;
-
-    @ConfigProperty(name = "graphqlcrud.datasource.dialect")
     private String dialect;
+
+
+    @Inject
+    public GraphQLResource(AgroalDataSource datasource, @ConfigProperty(name = "graphqlcrud.datasource.schema") String dbSchemaName,  @ConfigProperty(name = "graphqlcrud.datasource.dialect") String dialect) {
+        this.datasource = datasource;
+        this.dbSchemaName = dbSchemaName;
+        this.dialect = dialect;
+    }
 
     @POST
     public Map<String, Object> graphql(String query) throws Exception {


### PR DESCRIPTION
Otherwise this was printing the following warnings

```log
2020-09-14 10:05:20,029 INFO  [io.qua.arc.pro.BeanProcessor] (build-7) Found unrecommended usage of private members (use package-private instead) in application beans:
	- @Inject field io.graphqlcrud.app.GraphQLResource#datasource,
	- @Inject field io.graphqlcrud.app.GraphQLResource#dbSchemaName,
	- @Inject field io.graphqlcrud.app.GraphQLResource#dialect
```

since injection point with private access modifier is not recommended. We can change the access modifier to package private or if use constructor injection (my preference).